### PR TITLE
branch: pass `-u` to explicitly set upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,16 @@ branch -d [name]
 branch -D [name]
 ```
 
-And switching to a previous branch with `-`:
+Switching to a previous branch with `-`:
 
 ```
 branch -
+```
+
+Manually set an upstream merge target with `-u`. Works with both existing and new local branches.
+
+```
+branch -u origin/feature/my-long-branch-name localfeatre
 ```
 
 ### `merge`

--- a/branch
+++ b/branch
@@ -103,7 +103,7 @@ if [ -n "$local_branch_exists" ] && [ ! "$local_branch_exists" == '' ]; then
 
   # Explicitly set upstream if you specified "branch -u upstream/master upstream"
   if [ -n "$set_upstream_to" ]; then
-    echo "  Explicitly setting upstream to $set_upstream_to ..."
+    echo "  Explicitly setting upstream to $set_upstream_to..."
     git branch --set-upstream-to $branch $set_upstream_to
   fi
 

--- a/branch
+++ b/branch
@@ -19,6 +19,8 @@ delete=
 if [ "$1" == "-d" ] || [ "$1" == "-D" ]; then
   delete=$1
   branch=$2
+elif [ "$1" == "-u" ]; then
+  set_upstream_to=$1
 fi
 
 if [ -z $branch ]; then
@@ -59,6 +61,7 @@ if [ "$delete" ]; then
   exit 0
 fi
 
+# Try to find this branch among our remotes
 for remote in "${remotes[@]}";
 do
   remote_branch_exists=$(git branch -r --no-color | egrep " $remote/$branch\$")
@@ -70,11 +73,12 @@ do
   fi
 done
 
+# If there's an origin remote with the named branch, use it
+# Otherwise track the first matching branch alphabetically
 if [ ${#remotes_with_branch[@]} -gt 0 ]; then
-  # if there's an origin remote with the named branch, use it
   if [ "$origin_has_branch" = "1" ] ; then
     remote=origin
-  else # track the first matching branch alphabetically
+  else
     remote=${remotes[0]}
   fi
   remote_branch_exists="$remote/$branch"
@@ -95,6 +99,12 @@ if [ -n "$local_branch_exists" ] && [ ! "$local_branch_exists" == '' ]; then
     fi
   # else
   #   echo "Remote branch does not exist, not doing anything"
+  fi
+
+  # Explicitly set upstream if you specified "branch -u upstream/master upstream"
+  if [ -n "$set_upstream_to" ]; then
+    echo "  Explicitly setting upstream to $set_upstream_to ..."
+    git branch --set-upstream-to $branch $set_upstream_to
   fi
 
 # If remote exists, create a local branch that tracks the remote

--- a/branch
+++ b/branch
@@ -2,6 +2,7 @@
 #
 # Usage: branch [branchname]
 # Usage: branch [-D] [-d] [branchname]
+# Usage: branch [-u remote-upstream] [branchname]
 # Usage: branch -
 #
 #
@@ -20,7 +21,8 @@ if [ "$1" == "-d" ] || [ "$1" == "-D" ]; then
   delete=$1
   branch=$2
 elif [ "$1" == "-u" ]; then
-  set_upstream_to=$1
+  set_upstream_to=$2
+  branch=$3
 fi
 
 if [ -z $branch ]; then

--- a/branch
+++ b/branch
@@ -103,12 +103,6 @@ if [ -n "$local_branch_exists" ] && [ ! "$local_branch_exists" == '' ]; then
   #   echo "Remote branch does not exist, not doing anything"
   fi
 
-  # Explicitly set upstream if you specified "branch -u upstream/master upstream"
-  if [ -n "$set_upstream_to" ]; then
-    echo "  Explicitly setting upstream to $set_upstream_to..."
-    git branch --set-upstream-to $branch $set_upstream_to
-  fi
-
 # If remote exists, create a local branch that tracks the remote
 elif [ -n "$remote_branch_exists" ] && [ ! "$remote_branch_exists" == '' ]; then
   echo "📡  Tracking existing remote branch '$remote_branch_exists'..."
@@ -118,6 +112,12 @@ elif [ -n "$remote_branch_exists" ] && [ ! "$remote_branch_exists" == '' ]; then
 else
   echo "✏️  Creating new local branch..."
   git checkout -b $branch --no-track
+fi
+
+# Explicitly set upstream if you specified "branch -u upstream/master upstream"
+if [ -n "$set_upstream_to" ]; then
+  echo "  Explicitly setting upstream to $set_upstream_to..."
+  git branch --set-upstream-to $set_upstream_to
 fi
 
 exit 0


### PR DESCRIPTION
This PR adds a `-u` option to `branch` to set an explicit upstream remote tracking branch

This is one of those sorta annoying git commands I can never remember