### PR TITLE
branch: don't delete remote branches with -d/-D

### DIFF
--- a/branch
+++ b/branch
@@ -49,10 +49,6 @@ origin_has_branch=
 
 # Delete branch
 if [ "$delete" ]; then
-  if [ "$remote_branch_exists" ]; then
-    echo "💀  Removing remote branch..."
-    git push --delete $remote $branch
-  else
     echo "💀  Removing local branch..."
   fi
   git branch $delete $branch


### PR DESCRIPTION
Removes ability to delete branches at all. This is unexpected behavior 

I accidentally deleted a remote branch and closed a PR due to this issue: https://github.com/helpwithcovid/covid-volunteers/pull/167#event-3241801259

@sapegin if you don't object I'll issue a new version with the fix

Fixes #88 
