### PR TITLE
Add installation instructions for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Then update your `~/.bash_profile` or `~/.bashrc` to make git-friendly available
 export PATH=~/dev/git-friendly:$PATH
 ```
 
+### Fedora
+
+Unofficial builds of stable releases can be found in Fedora Copr:
+[fuhrmann/git-friendly](https://copr.fedorainfracloud.org/coprs/fuhrmann/git-friendly/).
+
+``` sh
+dnf copr enable fuhrmann/git-friendly
+dnf install git-friendly
+```
+
 ## Usage
 
 You now have some awesome new commands: **branch**, **merge**, **pull**, **push** and **stash**:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,17 @@ brew install git-friendly/git-friendly/git-friendly
 
 The Homebrew tap for this project [can be found here](https://github.com/git-friendly/homebrew-git-friendly)
 
-### Installer script
+### Fedora
+
+Unofficial builds of stable releases can be found in Fedora Copr:
+[fuhrmann/git-friendly](https://copr.fedorainfracloud.org/coprs/fuhrmann/git-friendly/).
+
+``` sh
+dnf copr enable fuhrmann/git-friendly
+dnf install git-friendly
+```
+
+### Installer script (curl)
 
 Run this one-liner, which will download the scripts into `/usr/local/bin`:
 
@@ -50,16 +60,6 @@ Then update your `~/.bash_profile` or `~/.bashrc` to make git-friendly available
 
 ```bash
 export PATH=~/dev/git-friendly:$PATH
-```
-
-### Fedora
-
-Unofficial builds of stable releases can be found in Fedora Copr:
-[fuhrmann/git-friendly](https://copr.fedorainfracloud.org/coprs/fuhrmann/git-friendly/).
-
-``` sh
-dnf copr enable fuhrmann/git-friendly
-dnf install git-friendly
 ```
 
 ## Usage


### PR DESCRIPTION
I've created a COPR so users can install git-friendly using dnf when in Fedora and keep git-friendly updated. The instructions are in the README.

You can check the build status for many other distributions here: https://copr.fedorainfracloud.org/coprs/fuhrmann/git-friendly/build/1341776/

I keep the spec file here in case you guys want to check it out: https://github.com/Fuhrmann/copr-specs

I plan to keep the COPR updated.