### PR TITLE
pull: add cargo support (rust)

### DIFF
--- a/pull
+++ b/pull
@@ -151,5 +151,14 @@ if [ "$GIT_FRIENDLY_NO_COMPOSER" != "true" ]; then
   fi
 fi
 
+# Install cargo dependencies (rust)
+if [ "$GIT_FRIENDLY_NO_CARGO" != "true" ]; then
+  if cmd_exists 'cargo' && has_changed 'Cargo.lock'; then
+    echo
+    echo '⚔  Building cargo --release...'
+    cargo build --release
+  fi
+fi
+
 echo "🦄  Done"
 exit 0


### PR DESCRIPTION
I'm very new to rust but thought this might be a nice add!

Can any rust experts advise on what the best equivalent
to a "bundle install" dependency-check-and-fetch might be, 
rather than fully building? And is `--release` a bad default?

