### PR TITLE
pull: fix redundant submodule recursion

### DIFF
--- a/pull
+++ b/pull
@@ -90,14 +90,14 @@ stash=$(git stash --include-untracked)
 
 # Update our remote
 echo "🚀  Fetching from $remote..."
-git fetch $remote || rollback $?
+git fetch --recurse-submodules=no $remote || rollback $?
 
 # Pull, using rebase if configured
 rebase="--rebase" # TODO disable if env-var is set
-git pull $rebase $remote $remote_branch || rollback $?
+git pull --recurse-submodules=no $rebase $remote $remote_branch || rollback $?
 
 # Update submodules
-git submodule update || rollback $?
+git submodule update --recursive || rollback $?
 
 unstash
 

--- a/pull
+++ b/pull
@@ -88,17 +88,12 @@ remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branc
 # Stash any local changes, including untracked files
 stash=$(git stash --include-untracked)
 
-# Update our remote
-echo "🚀  Fetching from $remote..."
-git fetch --recurse-submodules=no $remote || rollback $?
-
 # Pull, using rebase if configured
+echo "🚀  Fetching from $remote..."
 rebase="--rebase" # TODO disable if env-var is set
-git pull --recurse-submodules=no $rebase $remote $remote_branch || rollback $?
+git pull $rebase --recurse-submodules --jobs=10 $remote $remote_branch || rollback $?
 
-# Update submodules
-git submodule update --recursive || rollback $?
-
+# Pop any stashed changes
 unstash
 
 # Remove old, stale branches


### PR DESCRIPTION
Attempts to fix #93 -- feedback needed

This prevents duplicate submodule fetches, but I'm not sure it actually picks up submodule changes correctly.

Per feedback I set this to make `recurse-submodules` the default for `pull`. I am not a heavy submodule user but updating on every pull seems like a sane default to introduce -- please double-check me on this. Does the average submodule user always want to be up-to-date? I assume yes. 

I believe this will just bring the submodule up-to-date with its assigned commit, and will not forcibly update the submodule to the latest commit. That's also possible, but seems pretty aggressive as a default.

In my limited testing `git submodule update --recursive` does not seem to behave the same as "git {fetch,pull} --recurse-submodules=yes" -- the latter seem to actually explicitly go out and fetch every time? I can't quite figure out what the ideal behavior here is.

Additionally I also dropped the extra fetch inside `pull` since it is redundant with the `git pull` command