### PR TITLE
pull: stop if this isn't a git repository

### DIFF
--- a/branch
+++ b/branch
@@ -12,6 +12,9 @@
 # Executing without arguments prints all local & remote branches
 #
 
+# Abort if this isn't a git repository
+git rev-parse --is-inside-work-tree >/dev/null || exit $?
+
 remote="origin"
 branch=$1
 delete=

--- a/merge
+++ b/merge
@@ -15,6 +15,9 @@ if [ -z $branch ]; then
   exit 1
 fi
 
+# Abort if this isn't a git repository
+git rev-parse --is-inside-work-tree >/dev/null || exit $?
+
 # If there is a remote version of this branch, rebase onto current_branch first
 # If there's a remote (public) branch, we do not want to be rewriting histories
 tracking=$(git branch -vv | egrep "^\*" | awk '{ print $4 '})

--- a/pull
+++ b/pull
@@ -6,6 +6,9 @@
 # safely stashing and re-applying your local changes, if any
 #
 
+# Abort if this isn't a git repository
+git rev-parse --is-inside-work-tree >/dev/null || exit $?
+
 # Colors
 color_error="$(tput sgr 0 1)$(tput setaf 1)"
 color_reset="$(tput sgr0)"

--- a/push
+++ b/push
@@ -9,6 +9,9 @@
 # e.g. for doing "push -f"
 #
 
+# Abort if this isn't a git repository
+git rev-parse --is-inside-work-tree >/dev/null || exit $?
+
 # Get parent branch
 # https://stackoverflow.com/a/17843908/1973105
 function get_parent() {

--- a/stash
+++ b/stash
@@ -5,6 +5,9 @@
 # Stashes all changes (including untracked), or run git stash will all arguments
 #
 
+# Abort if this isn't a git repository
+git rev-parse --is-inside-work-tree >/dev/null || exit $?
+
 # If ran without arguments, stall all files, including untracked
 if [ -z "$1" ]; then
 	echo "🐿️  Stashing changes..."


### PR DESCRIPTION
See title! Previously we would get pretty far into the process before aborting.

Before:

```
$ pull
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
🚀  Fetching from origin...
fatal: not a git repository (or any of the parent directories): .git

Something went wrong, rolling back

🍯  Popping stash...
fatal: not a git repository (or any of the parent directories): .git

```

After:

```
$ pull
fatal: not a git repository (or any of the parent directories): .git
```