### PR TITLE
pull: run 'fetch --all' prior to pull

### DIFF
--- a/pull
+++ b/pull
@@ -88,8 +88,11 @@ remote_branch=$( (git config "branch.${branch}.merge" || echo "refs/heads/$branc
 # Stash any local changes, including untracked files
 stash=$(git stash --include-untracked)
 
+echo "📡 Fetching all remotes..."
+git fetch --all --jobs=10 || rollback $? # seems like pull does not in fact update all remotes... try this
+
 # Pull, using rebase if configured
-echo "🚀  Fetching from $remote..."
+echo "🚀  Pulling from $remote/$remote_branch..."
 rebase="--rebase" # TODO disable if env-var is set
 git pull $rebase --recurse-submodules --jobs=10 $remote $remote_branch || rollback $?
 


### PR DESCRIPTION
I like having all the remote branches available, and I can't find a variant for `git pull` that will do this. But I have a feeling it is possible

This doesn't add much speed-wise, but I can't shake the feeling this is doable with a single command :)

Consider this draft/WIP/just testing it out
