### PR TITLE
minor note re: zsh completion errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ Now you can type `branch`, press Tab and you’ll see a list of branches in your
 
 **Note:** You’ll need to adjust the path in the first line if you’re not using Homebrew or macOS.
 
+**Note:** If zsh complains, deleting your zsh completion cache may help resolve the issue: `rm -f ~/.zcompdump`
+
 ## License
 
 [MIT license](LICENSE.md).


### PR DESCRIPTION
How I resolved a cryptic zsh error that occurred after I installed git-friendly zsh completion:

    rm -f ~/.zcompdump

The error was: `(eval):setopt:3: no such option: NO_typesettounset`