### PR TITLE
pull: revert back to explicit 'git remote prune' invocation

### DIFF
--- a/pull
+++ b/pull
@@ -102,6 +102,7 @@ git pull $rebase --recurse-submodules --jobs=10 $remote $remote_branch || rollba
 unstash
 
 # Remove old, stale branches
+# This works a lot better than "git pull --prune" for unknown reasons
 git remote prune $remote >/dev/null 2>&1 &
 
 # Bundle em if you got em!

--- a/pull
+++ b/pull
@@ -96,10 +96,13 @@ else
   rebase="--no-rebase"
 fi
 
-git pull $rebase --prune --recurse-submodules --jobs=10 $remote $remote_branch || rollback $?
+git pull $rebase --recurse-submodules --jobs=10 $remote $remote_branch || rollback $?
 
 # Pop any stashed changes
 unstash
+
+# Remove old, stale branches
+git remote prune $remote >/dev/null 2>&1 &
 
 # Bundle em if you got em!
 if [ "$GIT_FRIENDLY_NO_BUNDLE" != "true" ]; then


### PR DESCRIPTION
I am not sure why, but "git pull --prune origin main" does not work nearly as well as "git remote prune origin main"

the docs would leave me to believe they are the same, but in my testing the last week or two, they are not

This does:

- Revert "Prune during 'pull' instead of separate command (#117)" commit 6330d3b1a75afb3724f5028dd2d53b96820936e7
